### PR TITLE
Change sub scope to `our`

### DIFF
--- a/lib/Holidays/US/Federal.rakumod
+++ b/lib/Holidays/US/Federal.rakumod
@@ -91,7 +91,7 @@ our %fedholidays is export = [
     },
 ];
 
-sub get-fedholidays(:$year!, :$debug --> Hash) is export {
+our sub get-fedholidays(:$year!, :$debug --> Hash) is export {
     my %h;
     for %fedholidays.keys -> $id {
         my FedHoliday $h = calc-holiday-dates :$year, :$id, :$debug;
@@ -108,7 +108,7 @@ sub get-fedholidays(:$year!, :$debug --> Hash) is export {
 #      it is observed on the previous Friday. When the date falls
 #      on a Sunday, it is observed on the following Monday.
 
-sub calc-holiday-dates(:$year!, :$id!, :$debug --> FedHoliday) is export {
+our sub calc-holiday-dates(:$year!, :$id!, :$debug --> FedHoliday) is export {
     # FedHolidays defined in the %fedholidays hash with attribute date => "0000-nn-nn" are subject to the weekend
     # rule and have two dates: actual and observed (which are the same
     # if the actual date is NOT on a weekend).
@@ -152,7 +152,7 @@ sub calc-holiday-dates(:$year!, :$id!, :$debug --> FedHoliday) is export {
     FedHoliday.new: :$date, :$date-observed, :$id, :$name, :$short-name;
 }
 
-sub calc-date(:$name!, :$year!, :$debug --> Date) is export {
+our sub calc-date(:$name!, :$year!, :$debug --> Date) is export {
     my Date $date;
     with $name {
         my ($month, $nth, $dow);


### PR DESCRIPTION
This is done so that users can optional load this module and still view the subroutines.  Without this change, something like this will not work:

`raku -Ilib -e 'my $a = try require ::("Holidays::US::Federal"); say ::("&Holidays::US::Federal::get-fedholidays")'`

If this was never your intent, please feel free to close the PR.